### PR TITLE
Feat : Install item pos | Fix : Dropped item reset, Mobile screen

### DIFF
--- a/Assets/MyAsset/01. Scenes/Main Scene.unity
+++ b/Assets/MyAsset/01. Scenes/Main Scene.unity
@@ -10660,6 +10660,7 @@ MonoBehaviour:
   m_ObjectPoolManager: {fileID: 261021296}
   m_GameSettingManager:
     m_TargetFrameRate: 60
+    m_CanvasScalers: []
   m_LaserManager:
     m_InitLazer: {fileID: 1915042229}
     m_LaserObject: {fileID: 6777635235316780505, guid: c476756df753be540a7889c2c5ae9fcb, type: 3}

--- a/Assets/MyAsset/03. Script/Controller/ToolbarController.cs
+++ b/Assets/MyAsset/03. Script/Controller/ToolbarController.cs
@@ -28,6 +28,7 @@ namespace LaserCrush.Controller.InputObject
         private Vector2 m_ItemInitDirection = Vector2.up;
 
         private const string m_ItemDownAudioKey = "ItemDown";
+        private const string m_ItemDragAudioKey = "ItemDrag";
         private const string m_ItemBatchFailAudioKey = "ItemBatchFail";
         private const string m_ItemBatchSuccessAudioKey = "ItemBatchSuccess";
 
@@ -99,7 +100,7 @@ namespace LaserCrush.Controller.InputObject
             AudioManager.AudioManagerInstance.PlayOneShotUISE(m_ItemDownAudioKey);
             m_CurrentItem = clickedItem;
             m_GridLineController.OnOffGridLine(true);
-            m_SubLineController.IsInitItemDrag(true);
+            m_SubLineController.IsInitItemDrag = true;
             m_IsInstallMode = true;
         }
 
@@ -177,7 +178,6 @@ namespace LaserCrush.Controller.InputObject
             m_ControllingTransform = m_InstalledItemPool[m_CurrentItem.ItemIndex].GetObject(true).transform;
             m_ControllingTransform.transform.SetPositionAndRotation(Vector2.zero, Quaternion.LookRotation(Vector3.forward, Vector3.up));
             
-            //m_ControllingTransform = Instantiate(m_CurrentItem.ItemObject, Vector2.zero, Quaternion.identity, m_BatchedItemTransform).transform;
             m_ControllingItem = m_ControllingTransform.GetComponent<InstalledItem>();
             m_ControllingItem.ReInit();
         }
@@ -188,6 +188,10 @@ namespace LaserCrush.Controller.InputObject
             else
             {
                 Result result = (Result)(m_CheckAvailablePosFunc?.Invoke(hit2D.point));
+
+                if((Vector2)m_ControllingTransform.position != result.m_ItemGridPos)
+                    AudioManager.AudioManagerInstance.PlayOneShotUISE(m_ItemDragAudioKey);
+
                 if (!result.m_IsAvailable) m_ControllingTransform.position = Vector3.zero;
                 else m_ControllingTransform.position = result.m_ItemGridPos;
             }
@@ -222,12 +226,15 @@ namespace LaserCrush.Controller.InputObject
             m_IsDragging = false;
             m_IsInstallMode = false;
             m_GridLineController.OnOffGridLine(false);
-            m_SubLineController.IsInitItemDrag(false);
+            m_SubLineController.IsInitItemDrag = false ;
             m_SubLineController.UpdateLineRenderer();
         }
         #endregion
 
         private void OnDestroy()
-            => m_AddInstallItemAction = null;
+        {
+            m_CheckAvailablePosFunc = null;
+            m_AddInstallItemAction = null;
+        }
     }
 }

--- a/Assets/MyAsset/03. Script/Entity/Energy.cs
+++ b/Assets/MyAsset/03. Script/Entity/Energy.cs
@@ -14,7 +14,7 @@ namespace LaserCrush.Entity
         private static event Action s_CurrentEnergyUpdateAction;
         private static event Action s_MaxEnergyHighlightTextAction;
 
-        private static int s_InitEnergy = 2000;
+        private static readonly int s_InitEnergy = 2000;
         private static int s_MaxEnergy;
         private static int s_CurrentEnergy;
         private static int s_HittingFloorLaserNum;

--- a/Assets/MyAsset/03. Script/Entity/Item/InstalledItem/InstalledItem.cs
+++ b/Assets/MyAsset/03. Script/Entity/Item/InstalledItem/InstalledItem.cs
@@ -53,7 +53,7 @@ namespace LaserCrush.Entity.Item
         private static readonly float [] m_FontSizes = { 3.25f, 2.75f, 2.25f};
         private static readonly float[] m_ChargingEnergy = { 0.3f, 0.4f, 0.7f};
 
-        private const string m_ItemDragAudiKey = "ItemDrag";
+        private const string m_ItemDragAudioKey = "ItemDrag";
 
         private const string m_FixedNoticeAnimationKey = "FixedNotice";
         private const string m_DestroyAnimationKey = "Destroy";
@@ -209,11 +209,24 @@ namespace LaserCrush.Entity.Item
             Vector2 lineDir = m_LineRenderers[i].transform.up;
 
             RaycastHit2D hit = Physics2D.Raycast(linePos, lineDir, length, RayManager.s_LaserHitableLayer);
-            Vector2 secondPos = hit.collider is null ? linePos + lineDir * length : hit.point;
+            Vector2 secondPos = hit.collider is null ? linePos + lineDir * m_SubLineLength : hit.point;
 
             m_LineRenderers[i].positionCount = 2;
             m_LineRenderers[i].SetPosition(0, linePos);
             m_LineRenderers[i].SetPosition(1, secondPos);
+        }
+
+        public void SetPosition(Vector2 pos, int rowNumber, int colNumber)
+        {
+            if (RowNumber != rowNumber || ColNumber != colNumber)
+            {
+                AudioManager.AudioManagerInstance.PlayOneShotUISE(m_ItemDragAudioKey);
+                Position = pos;
+                RowNumber = rowNumber;
+                ColNumber = colNumber;
+                transform.position = pos;
+                SetAdjustLine(Mathf.Infinity);
+            }
         }
 
         public void SetDirection(Vector2 pos)
@@ -223,7 +236,7 @@ namespace LaserCrush.Entity.Item
 
             if (Direction != discreteDirection)
             {
-                AudioManager.AudioManagerInstance.PlayOneShotUISE(m_ItemDragAudiKey);
+                AudioManager.AudioManagerInstance.PlayOneShotUISE(m_ItemDragAudioKey);
                 Direction = discreteDirection;
                 transform.rotation = Quaternion.LookRotation(transform.forward, discreteDirection);
                 SetAdjustLine(Mathf.Infinity);

--- a/Assets/MyAsset/03. Script/Manager/BlockManager.cs
+++ b/Assets/MyAsset/03. Script/Manager/BlockManager.cs
@@ -68,6 +68,7 @@ namespace LaserCrush.Manager
         private Vector2 m_MoveDownVector;
         #endregion
 
+        #region Init
         public void Init(ItemManager itemManager)
         {
             m_Blocks = new List<Block>();
@@ -98,6 +99,7 @@ namespace LaserCrush.Manager
                 m_DroppedItemPool[i].GenerateObj(m_DroppedItemPoolingCount[i]);
             }
         }
+        #endregion
 
         #region Grid Related
         private Result CheckAvailablePos(Vector3 pos)
@@ -287,7 +289,7 @@ namespace LaserCrush.Manager
 
                 DroppedItem droppedItem = (DroppedItem)m_DroppedItemPool[typeIndex - 1].GetObject(true);
                 droppedItem.transform.position = block.Position;
-                droppedItem.ReturnAction += m_DroppedItemPool[typeIndex - 1].ReturnObject;
+                droppedItem.Init(m_DroppedItemPool[typeIndex - 1].ReturnObject);
                 m_ItemManager.AddDroppedItem(droppedItem);
             }
 
@@ -358,6 +360,9 @@ namespace LaserCrush.Manager
 
         public void ResetGame()
         {
+            m_MoveDownElapsedTime = 0;
+            m_GenerateElapsedTime = 0;
+
             foreach (var block in m_Blocks)
             {
                 block.ImmediatelyReset();

--- a/Assets/MyAsset/03. Script/Manager/GameManager.cs
+++ b/Assets/MyAsset/03. Script/Manager/GameManager.cs
@@ -96,12 +96,11 @@ namespace LaserCrush.Manager
 
             m_LaserManager.Init();
             m_BlockManager.Init(m_ItemManager);
-            m_ItemManager.Init(m_ToolbarController);
+            m_ItemManager.Init(m_ToolbarController, m_SubLineController);
 
             GetComponent<Energy>().Init(DataManager.GameData.m_Energy);
 
-            m_SubLineController.OnClickAction += EndDeploying;
-            m_SubLineController.Init();
+            m_SubLineController.Init(EndDeploying);
 
             if (hasData) m_SubLineController.IsActiveSubLine = true;
 
@@ -263,7 +262,7 @@ namespace LaserCrush.Manager
 
         public void SetInteraction(bool value)
         {
-            m_SubLineController.CanInteraction(value);
+            m_SubLineController.CanInteraction = value;
             m_ToolbarController.CanInteraction(value);
         }
 

--- a/Assets/MyAsset/03. Script/Manager/GameSettingManager.cs
+++ b/Assets/MyAsset/03. Script/Manager/GameSettingManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace LaserCrush.Manager
 {
@@ -6,6 +7,7 @@ namespace LaserCrush.Manager
     public class GameSettingManager
     {
         [SerializeField] private int m_TargetFrameRate = 60;
+        [SerializeField] private CanvasScaler[] m_CanvasScalers;
 
         public void Init()
         {
@@ -29,7 +31,11 @@ namespace LaserCrush.Manager
             int deviceWidth = Screen.width; // 현재 기기 너비
             int deviceHeight = Screen.height; // 현재 기기 높이
 
-            Screen.SetResolution(setWidth, (int)((float)deviceHeight / deviceWidth * setWidth), true);
+            for(int i =0;i< m_CanvasScalers.Length; i++)
+            {
+                m_CanvasScalers[i].referenceResolution *= new Vector2(m_CanvasScalers[i].referenceResolution.x / Screen.width, Screen.height / m_CanvasScalers[i].referenceResolution.y);
+            }
+            //Screen.SetResolution(setWidth, (int)((float)deviceHeight / deviceWidth * setWidth), true);
 
             Rect rect;
             if ((float)setWidth / setHeight < (float)deviceWidth / deviceHeight) // 기기의 해상도 비가 더 큰 경우

--- a/Assets/MyAsset/03. Script/Manager/RayManager.cs
+++ b/Assets/MyAsset/03. Script/Manager/RayManager.cs
@@ -20,23 +20,26 @@ namespace LaserCrush.Manager
 
         public static Camera MainCamera { get; set; }
 
-
+        #region PC
         public static bool RaycastToClickable(out RaycastHit2D hit, int layer)
         {
-            hit = Physics2D.Raycast(MainCamera.ScreenToWorldPoint(Input.mousePosition), Vector2.zero, layer);
+            hit = Physics2D.Raycast(MainCamera.ScreenToWorldPoint(Input.mousePosition), Vector3.forward, Mathf.Infinity, layer);
             return hit.collider != null;
         }
 
         public static Vector3 MousePointToWorldPoint()
             => MainCamera.ScreenToWorldPoint(Input.mousePosition) + new Vector3(0, 0, 10);
+        #endregion
 
+        #region Mobile
         public static bool RaycastToTouchable(out RaycastHit2D hit, int layer, Touch touch)
         {
-            hit = Physics2D.Raycast(MainCamera.ScreenToWorldPoint(touch.position), Vector2.zero, layer);
+            hit = Physics2D.Raycast(MainCamera.ScreenToWorldPoint(touch.position), Vector3.forward, Mathf.Infinity, layer);
             return hit.collider != null;
         }
 
         public static Vector3 TouchPointToWorldPoint(Touch touch)
             => MainCamera.ScreenToWorldPoint(touch.position) + new Vector3(0, 0, 10);
+        #endregion
     }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,10 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.12
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 11400000, guid: e5b18ed2c55d15841a3a51a22133da27, type: 2}
+  - {fileID: 11400000, guid: e06fd831bb84f514f9fd0a0c730a05a6, type: 2}
+  - {fileID: -2287081422995410892, guid: fdd448ac9b99bd54fa5582c07a56f901, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
[Feat]
설치한 아이템 해당 턴에만 위치 수정 가능
[Fix]
아이템 떨어진 상황에서 타이밍 맞게 게임 Reset시 아이템이 먹어지던 문제 해결
모바일 빌드 버전에서 가끔씩 빈 검은 화면이 반짝이던 문제 해결